### PR TITLE
Fix heroku errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-gunicorn
-dash
-plotly
-pandas
-numpy
+dash==1.16.3
+dash_html_components==1.1.1
+pandas==1.1.4
+dash_core_components==1.12.1
+plotly==4.10.0
+numpy==1.17.5
+dash_bootstrap_components==0.10.7
 git+git://github.com/PSLmodels/microdf.git#egg=microdf
+gunicorn


### PR DESCRIPTION
Generated this with ```pipreqs --force``` - I think the problem was the lack of dash_bootstrap_components, but this has the version numbers as well. My fork of this repo [deploys successfully](https://secret-beach-86190.herokuapp.com/).