### PR TITLE
Drop pandas pin and install us with conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,10 +6,10 @@ dependencies:
   - dash
   - dash-bootstrap-components
   - plotly
-  - "pandas>=1.2.3"
+  - pandas
   - numpy
+  - us
   - pip
   - pip:
       - jupyter-book
-      - us
       - "git+https://github.com/PSLmodels/microdf"


### PR DESCRIPTION
@MaxGhenis I tested this locally and it worked fine without the pandas pin. I think the pandas pin was there from a prior C/S build issue. Since then I removed pandas from the base image. 

I also moved `us` back to being installed with conda in hopes of resolving the issue here: https://github.com/compute-tooling/compute-studio-publish/runs/2852112587#step:9:60.