### PR TITLE
Remove unnecessary cs-config directory

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,1 +1,0 @@
-csk build-env


### PR DESCRIPTION
The `csk build-env` command is now run by default during the build process so this is no longer needed.